### PR TITLE
edit(writing): improve description and post-item line clamp

### DIFF
--- a/components/post-item.tsx
+++ b/components/post-item.tsx
@@ -32,7 +32,7 @@ export function PostItem({
           <h2 className="text-xl font-bold tracking-tight">{title}</h2>
 
           {description && (
-            <div className="text-muted-foreground line-clamp-2">
+            <div className="text-muted-foreground line-clamp-3">
               {description}
             </div>
           )}

--- a/content/writing/47-experiments-in-3-days.mdx
+++ b/content/writing/47-experiments-in-3-days.mdx
@@ -1,6 +1,6 @@
 ---
 title: '47 experiments in 3 days: I let Claude Code optimize a Ray Data pipeline while I was sleeping'
-description: "A customer's batch embeddings pipeline was crashing at 10M rows. 47 autonomous experiments later, it shipped 3.2× faster on 60% fewer GPUs."
+description: "I gave Claude Code a scoring function, an objective file, and a stuck embeddings pipeline. It halved the GPU count and cost, finding fixes I wouldn't have tried."
 date: 2026-05-12
 tags: ['anyscale', 'ray', 'ai-agents', 'optimization']
 published: true


### PR DESCRIPTION
## Summary
- Rewrote the 47-experiments post description so it complements the title (method + outcome) instead of repeating "47 experiments"
- Replaced a single em-dash with a comma for cleaner sentence flow
- Bumped `line-clamp-2` to `line-clamp-3` on `PostItem` so longer descriptions aren't truncated on the /writing listing page

## Test plan
- [ ] Verify `/writing` page shows full descriptions without cutoff
- [ ] Verify the 47-experiments post renders correctly with the updated frontmatter

Made with [Cursor](https://cursor.com)