### PR TITLE
Brand: add nj favicon set + fix stale metadata colors

### DIFF
--- a/components/brand/nj-mark.tsx
+++ b/components/brand/nj-mark.tsx
@@ -101,7 +101,7 @@ export function NJWordmark({
 export function NJLockup({
   size = 32,
   accent = NJ_PEACH,
-  ink = '#4c4f69',
+  ink = 'hsl(var(--foreground))',
   showWordmark = true
 }: {
   size?: number;

--- a/config/metadata.ts
+++ b/config/metadata.ts
@@ -6,7 +6,7 @@ export const siteMetadata = {
   siteUrl: 'https://nehiljain.com',
   siteName: DATA.name,
   twitterHandle: '@nehiljain',
-  socialImage: '/static/favicons/og-image.png', // Assuming you have this
+  socialImage: '/favicons/og-image.png',
   locale: 'en-US',
   analytics: {
     googleAnalyticsId: '' // Add if you have GA


### PR DESCRIPTION
## Summary

Adds the full **nj favicon set** (18 files) from the Claude Design handoff bundle and fixes three stale color tokens in `app/layout.tsx`.

## Why

The site's `<head>` has been referencing `/static/favicons/*` for a while, but **the directory never existed in `public/`** — `public/static/` is owned by Velite with `clean: true` ([velite.config.ts:62](https://github.com/nehiljain/nehiljain.com/blob/master/velite.config.ts#L62)), so every build wipes that path. Result: every favicon, the manifest, the OG image, and the mask-icon have been 404ing in production.

Assets now live at **`/favicons/`** (outside Velite's managed tree) which matches the design bundle's snippet exactly.

## The `nj` legibility fix

Per the design chat, an earlier version of the `nj` mark used `fontSize = h * 1.05`, which made the letters leak outside the peach blob — at 16×16 they merged into background strokes. The new assets use `fontPx = h * 0.78` and ellipse `ry = h * 0.46` so the letters fit *inside* the peach ellipse. The 16-px favicon now reads as a peach blob with legible cream `nj` instead of a smudge of dark strokes.

## Files added (`public/favicons/`)

- `favicon.ico` (multi-size 16/32/48) + `favicon.svg`
- PNG: 16, 32, 48, 96, 1024 (master)
- Apple touch: 120, 152, 167, 180 (default)
- Android PWA: 192, 512
- OG: 1200×630 + 1200×1200 square
- `safari-pinned-tab.svg`, `site.webmanifest`, `browserconfig.xml`

## Color fixes in `app/layout.tsx`

| Token | Before | After | Why |
|---|---|---|---|
| `theme-color` | `#ffffff` | `#fe640b` | brand peach (was browser default) |
| `msapplication-TileColor` | `#da532c` | `#ece9e2` | brand cream paper (was leftover from shadcn template) |
| `mask-icon` color | `#5bbad5` | `#fe640b` | brand peach (was leftover from shadcn template) |

Plus `config/metadata.ts`: `socialImage` path `/static/favicons/og-image.png` → `/favicons/og-image.png`.

## Test plan

- [x] `pnpm build` clean — 73 pages, no missing-asset errors
- [x] 18 files survive `public/static/` cleanup (verified by counting files after build)
- [ ] Reviewer: hit `/favicons/favicon.ico` and `/favicons/og-image.png` on the deploy preview, confirm 200s
- [ ] Reviewer: paste deploy-preview URL in iMessage/Slack, confirm OG card shows the nj mark
- [ ] Reviewer: pin a tab in Safari, confirm mask-icon renders peach

🤖 Generated with [Claude Code](https://claude.com/claude-code)