### PR TITLE
Drop post numbering, shrink hero portrait, unify headings

### DIFF
--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -28,7 +28,7 @@ export default function WritingPage() {
       <div className="mt-10 grid gap-14 lg:grid-cols-[1fr_260px]">
         <div>
           {all.map((p, i) => (
-            <EditorialRow key={p.slug} post={p} index={i} accent={i === 0} />
+            <EditorialRow key={p.slug} post={p} accent={i === 0} />
           ))}
         </div>
         <WritingSidebar posts={all} />

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -32,7 +32,7 @@ export function HomeHero() {
         </div>
       </div>
       <div className="relative grid place-items-center">
-        <ProfilePortrait size={300} src={DATA.avatarUrl} />
+        <ProfilePortrait size={240} src={DATA.avatarUrl} />
       </div>
     </section>
   );

--- a/components/home/latest-posts.tsx
+++ b/components/home/latest-posts.tsx
@@ -25,7 +25,6 @@ export function HomeLatestPosts() {
               image: p.image,
               body: p.body
             }}
-            index={i}
             accent={i === 0}
           />
         ))}

--- a/components/writing/editorial-row.tsx
+++ b/components/writing/editorial-row.tsx
@@ -14,26 +14,22 @@ export type EditorialPost = {
   body?: string;
 };
 
-type Props = { post: EditorialPost; index: number; accent?: boolean };
+type Props = { post: EditorialPost; accent?: boolean };
 
-export function EditorialRow({ post, index, accent = false }: Props) {
+export function EditorialRow({ post, accent = false }: Props) {
   const hasImage = !!post.image;
   const readTime = post.body ? getReadingTime(post.body) : null;
-  const titleSize = accent ? 'text-2xl sm:text-3xl' : 'text-xl sm:text-2xl';
+  const titleSize = 'text-xl sm:text-2xl';
 
   return (
     <Link
       href={'/' + post.slug}
       className={`group grid items-start gap-6 border-t border-rule/40 py-6 no-underline text-foreground ${
         hasImage
-          ? 'grid-cols-[52px_minmax(0,1fr)_200px]'
-          : 'grid-cols-[52px_minmax(0,1fr)]'
+          ? 'grid-cols-[minmax(0,1fr)_200px]'
+          : 'grid-cols-[minmax(0,1fr)]'
       }`}
     >
-      <div className="pt-1 font-mono text-[11px] font-semibold tracking-wide text-muted-foreground transition-colors duration-200 group-hover:text-accent">
-        {String(index + 1).padStart(2, '0')}
-      </div>
-
       <div className="min-w-0">
         <div className="mb-1.5 flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[11px] text-muted-foreground">
           <span>{formatDate(post.date)}</span>

--- a/components/writing/writing-hero.tsx
+++ b/components/writing/writing-hero.tsx
@@ -1,7 +1,7 @@
 export function WritingHero() {
   return (
     <section className="border-b border-dashed border-rule pb-7">
-      <h1 className="m-0 font-heading text-6xl font-semibold leading-[1.0] tracking-tight text-foreground lg:text-[84px]">
+      <h1 className="m-0 font-heading text-5xl font-semibold leading-[1.02] tracking-tight text-foreground lg:text-[64px]">
         Notes from the field<span className="text-accent">.</span>
       </h1>
       <p className="mt-3.5 max-w-[640px] text-[19px] leading-snug text-muted-foreground">


### PR DESCRIPTION
## Summary
- Remove the `01/02/03` index column from the editorial post list — it took up space without adding value for a simple article list. Applied to both the home **Latest** section and the **/writing** index.
- Shrink the home hero profile portrait by 20% (`size={300}` → `240`) — it was too large.
- Align the `/writing` page heading ("Notes from the field.") with the home hero heading size (`text-5xl lg:text-[64px]`).
- Make the first (accent) post title match the size of all other post titles.

## Notes for reviewer
- This branch was 2 commits behind `master`; merged `master` in to pick up the earlier hero heading/description size reduction (`cc54a1b`).
- `EditorialRow` no longer takes an `index` prop; both call sites updated.
- A local `.claude/launch.json` was created for the preview dev server — left untracked, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)